### PR TITLE
Refactor elements from the core templates

### DIFF
--- a/.check-author.yml
+++ b/.check-author.yml
@@ -1,0 +1,2 @@
+exclude:
+  languages

--- a/contao/config/autoload.php
+++ b/contao/config/autoload.php
@@ -13,7 +13,8 @@
  * @package    MetaModels
  * @subpackage ContaoFrontendEditing
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
- * @copyright  2016 The MetaModels team.
+ * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
+ * @copyright  2016-2017 The MetaModels team.
  * @license    https://github.com/MetaModels/contao-frontend-editing/blob/master/LICENSE LGPL-3.0
  * @filesource
  */
@@ -25,4 +26,6 @@ TemplateLoader::addFiles(array
 (
     'ce_metamodel_frontend_edit'  => 'system/modules/metamodels-contao-frontend-editing/templates',
     'mod_metamodel_frontend_edit' => 'system/modules/metamodels-contao-frontend-editing/templates',
+    'ce_metamodel_list_edit'      => 'system/modules/metamodels-contao-frontend-editing/templates',
+    'mod_metamodel_list_edit'     => 'system/modules/metamodels-contao-frontend-editing/templates',
 ));

--- a/contao/templates/ce_metamodel_frontend_edit.html5
+++ b/contao/templates/ce_metamodel_frontend_edit.html5
@@ -1,10 +1,5 @@
-<!-- indexer::stop -->
-<div class="<?php echo $this->class; ?> block"<?php echo $this->cssID; ?><?php if ($this->style): ?> style="<?php echo $this->style; ?>"<?php endif; ?>>
-<?php if ($this->headline): ?>
-<<?php echo $this->hl; ?>><?php echo $this->headline; ?></<?php echo $this->hl; ?>>
-<?php endif; ?>
+<?php $this->extend('block_unsearchable'); ?>
 
-<?php echo $this->editor; ?>
-
-</div>
-<!-- indexer::continue -->
+<?php $this->block('content'); ?>
+<?= $this->editor ?>
+<?php $this->endblock(); ?>

--- a/contao/templates/ce_metamodel_frontend_edit.xhtml
+++ b/contao/templates/ce_metamodel_frontend_edit.xhtml
@@ -1,10 +1,5 @@
-<!-- indexer::stop -->
-<div class="<?php echo $this->class; ?> block"<?php echo $this->cssID; ?><?php if ($this->style): ?> style="<?php echo $this->style; ?>"<?php endif; ?>>
-<?php if ($this->headline): ?>
-<<?php echo $this->hl; ?>><?php echo $this->headline; ?></<?php echo $this->hl; ?>>
-<?php endif; ?>
+<?php $this->extend('block_unsearchable'); ?>
 
-<?php echo $this->editor; ?>
-
-</div>
-<!-- indexer::continue -->
+<?php $this->block('content'); ?>
+<?= $this->editor ?>
+<?php $this->endblock(); ?>

--- a/contao/templates/ce_metamodel_list_edit.html5
+++ b/contao/templates/ce_metamodel_list_edit.html5
@@ -1,0 +1,9 @@
+<?php $this->extend('ce_metamodel_list'); ?>
+
+<?php $this->block('content'); ?>
+<?php if ($this->editEnable): ?>
+<div class="addUrl"><a href="<?= $this->addUrl ?>"><?= $this->addNewLabel ?></a></div>
+<?php endif; ?>
+
+<?php $this->parent(); ?>
+<?php $this->endblock(); ?>

--- a/contao/templates/ce_metamodel_list_edit.xhtml
+++ b/contao/templates/ce_metamodel_list_edit.xhtml
@@ -1,0 +1,9 @@
+<?php $this->extend('ce_metamodel_list'); ?>
+
+<?php $this->block('content'); ?>
+<?php if ($this->editEnable): ?>
+<div class="addUrl"><a href="<?= $this->addUrl ?>"><?= $this->addNewLabel ?></a></div>
+<?php endif; ?>
+
+<?php $this->parent(); ?>
+<?php $this->endblock(); ?>

--- a/contao/templates/mod_metamodel_frontend_edit.html5
+++ b/contao/templates/mod_metamodel_frontend_edit.html5
@@ -1,10 +1,5 @@
-<!-- indexer::stop -->
-<div class="<?php echo $this->class; ?> block"<?php echo $this->cssID; ?><?php if ($this->style): ?> style="<?php echo $this->style; ?>"<?php endif; ?>>
-<?php if ($this->headline): ?>
-<<?php echo $this->hl; ?>><?php echo $this->headline; ?></<?php echo $this->hl; ?>>
-<?php endif; ?>
+<?php $this->extend('block_unsearchable'); ?>
 
-<?php echo $this->editor; ?>
-
-</div>
-<!-- indexer::continue -->
+<?php $this->block('content'); ?>
+<?= $this->editor ?>
+<?php $this->endblock(); ?>

--- a/contao/templates/mod_metamodel_frontend_edit.xhtml
+++ b/contao/templates/mod_metamodel_frontend_edit.xhtml
@@ -1,10 +1,5 @@
-<!-- indexer::stop -->
-<div class="<?php echo $this->class; ?> block"<?php echo $this->cssID; ?><?php if ($this->style): ?> style="<?php echo $this->style; ?>"<?php endif; ?>>
-<?php if ($this->headline): ?>
-<<?php echo $this->hl; ?>><?php echo $this->headline; ?></<?php echo $this->hl; ?>>
-<?php endif; ?>
+<?php $this->extend('block_unsearchable'); ?>
 
-<?php echo $this->editor; ?>
-
-</div>
-<!-- indexer::continue -->
+<?php $this->block('content'); ?>
+<?= $this->editor ?>
+<?php $this->endblock(); ?>

--- a/contao/templates/mod_metamodel_list_edit.html5
+++ b/contao/templates/mod_metamodel_list_edit.html5
@@ -1,0 +1,9 @@
+<?php $this->extend('ce_metamodel_list'); ?>
+
+<?php $this->block('content'); ?>
+<?php if ($this->editEnable): ?>
+<div class="addUrl"><a href="<?= $this->addUrl ?>"><?= $this->addNewLabel ?></a></div>
+<?php endif; ?>
+
+<?php $this->parent(); ?>
+<?php $this->endblock(); ?>

--- a/contao/templates/mod_metamodel_list_edit.xhtml
+++ b/contao/templates/mod_metamodel_list_edit.xhtml
@@ -1,0 +1,9 @@
+<?php $this->extend('ce_metamodel_list'); ?>
+
+<?php $this->block('content'); ?>
+<?php if ($this->editEnable): ?>
+<div class="addUrl"><a href="<?= $this->addUrl ?>"><?= $this->addNewLabel ?></a></div>
+<?php endif; ?>
+
+<?php $this->parent(); ?>
+<?php $this->endblock(); ?>

--- a/src/EventListener/RenderItemListListener.php
+++ b/src/EventListener/RenderItemListListener.php
@@ -3,7 +3,7 @@
 /**
  * This file is part of MetaModels/contao-frontend-editing.
  *
- * (c) 2016 The MetaModels team.
+ * (c) 2016-2017 The MetaModels team.
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
@@ -13,7 +13,8 @@
  * @package    MetaModels
  * @subpackage ContaoFrontendEditing
  * @author     Christian Schiffler <c.schiffler@cyberspectrum.de>
- * @copyright  2016 The MetaModels team.
+ * @author     Richard Henkenjohann <richardhenkenjohann@googlemail.com>
+ * @copyright  2016-2017 The MetaModels team.
  * @license    https://github.com/MetaModels/contao-frontend-editing/blob/master/LICENSE LGPL-3.0
  * @filesource
  */
@@ -64,11 +65,16 @@ class RenderItemListListener
         $parsed     = $event->getResult();
         $item       = $event->getItem();
 
-        $parsed['editUrl'] = $this->generateEditUrl(
-            $dispatcher,
-            $settings->get(self::FRONTEND_EDITING_PAGE),
-            ModelId::fromValues($item->getMetaModel()->getTableName(), $event->getItem()->get('id'))->getSerialized()
-        );
+        $parsed['actions']['edit'] = [
+            'label' => $GLOBALS['TL_LANG']['MSC']['metamodel_edit_item'],
+            'href'  => $this->generateEditUrl(
+                $dispatcher,
+                $settings->get(self::FRONTEND_EDITING_PAGE),
+                ModelId::fromValues($item->getMetaModel()->getTableName(), $event->getItem()->get('id'))
+                    ->getSerialized()
+            ),
+            'class' => 'edit',
+        ];
 
         $event->setResult($parsed);
     }
@@ -103,10 +109,9 @@ class RenderItemListListener
         if ($enabled) {
             $url = $this->generateAddUrl($dispatcher, $page);
 
-            $event->getTemplate()->addUrl    = $url;
-            $event->getTemplate()->editLabel = $GLOBALS['TL_LANG']['MSC']['metamodel_edit_item'];
             $caller->Template->addUrl        = $url;
             $caller->Template->addNewLabel   = $GLOBALS['TL_LANG']['MSC']['metamodel_add_item'];
+            $event->getTemplate()->addUrl    = $url;
 
             $event->getList()->getView()->set(self::FRONTEND_EDITING_PAGE, $page);
         }


### PR DESCRIPTION
## Description

Add the variable `createEnable` to the MetaModel list template. There is no need to show the `addUrl` button if the table is not creatable.

## Checklist
- [x] Read and understood the [CONTRIBUTING guidelines](CONTRIBUTING.md)
- [ ] Created tests, if possible
- [ ] All tests passing
- [ ] Extended the README / documentation, if necessary
- [x] Added myself to the `@authors` in touched PHP files
- [ ] Checked the changes with phpcq and introduced no new issues
